### PR TITLE
Add ignore option

### DIFF
--- a/frontend/src/app/Popover.tsx
+++ b/frontend/src/app/Popover.tsx
@@ -7,7 +7,7 @@ interface PopoverProps {
   disableReplace?: boolean;
 }
 
-const useOutsideAlerter = (ref: React.RefObject<HTMLDivElement>, onClose: () => void) => {
+const useOutsideAlerter = (ref: React.RefObject<HTMLDivElement | null>, onClose: () => void) => {
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
       if (ref.current && !ref.current.contains(event.target as Node)) {
@@ -24,7 +24,7 @@ const useOutsideAlerter = (ref: React.RefObject<HTMLDivElement>, onClose: () => 
 
 
 export default function Popover({ onSelect, onClose, suggestions, disableReplace }: PopoverProps) {
-  const wrapperRef = useRef<HTMLDivElement>(null);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
   useOutsideAlerter(wrapperRef, onClose);
 
   const handleSelect = (item: string) => {
@@ -49,6 +49,12 @@ export default function Popover({ onSelect, onClose, suggestions, disableReplace
             {item}
           </button>
         ))}
+        <button
+          onClick={onClose}
+          className="px-3 py-1 bg-gray-600 text-white rounded hover:bg-gray-500"
+        >
+          Ignore
+        </button>
       </div>
       <button onClick={onClose} className="mt-2 w-full text-center text-xs text-gray-400 hover:text-white">Close</button>
     </div>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -127,6 +127,10 @@ export default function Home() {
     setActivePopover(null);
   }
 
+  const handleIgnore = () => {
+    setActivePopover(null);
+  }
+
   const handleReplaceAll = (type: 'em_dash' | 'cliche' | 'jargon' | 'ai_tell') => {
     const replacementText = (document.getElementById('replace-all-input') as HTMLInputElement).value;
     const newSegments = segments.map(segment => {
@@ -196,7 +200,7 @@ export default function Home() {
                     {activePopover === index && (
                       <Popover
                         onSelect={(suggestion) => handleReplace(index, suggestion)}
-                        onClose={() => setActivePopover(null)}
+                        onClose={handleIgnore}
                         suggestions={segment.suggestions || []}
                         disableReplace={segment.type === 'long_sentence'}
                       />


### PR DESCRIPTION
## Summary
- add an Ignore button to the Popover component
- close the popover without replacing text when Ignore is clicked
- expose `handleIgnore` in page logic and wire popover to it

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68743c36675c8331916e76ea515c0a13